### PR TITLE
Compatibility with NPCs Names Distributor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ target_sources(
 	${PROJECT_NAME}
 	PRIVATE
 	src/SubtitleManager.cpp
+	src/NPCNameProvider.cpp
 )
 
 target_include_directories(

--- a/include/NND_API.h
+++ b/include/NND_API.h
@@ -1,0 +1,88 @@
+
+#pragma once
+
+/*
+* For modders: Copy this file into your own project if you wish to use this API
+*/
+namespace NND_API
+{
+	constexpr auto NNDPluginName = "NPCsNamesDistributor";
+
+	// Available NND interface versions
+	enum class InterfaceVersion : uint8_t
+	{
+		kV1
+	};
+
+	enum class NameContext : uint8_t
+	{
+		kCrosshair = 1,
+		kCrosshairMinion,
+
+		kSubtitles,
+		kDialogue,
+
+		kInventory,
+
+		kBarter,
+
+		kEnemyHUD,
+
+		kOther
+	};
+
+	// NND's modder interface
+	class IVNND1
+	{
+	public:
+
+		/// <summary>
+		/// Retrieves a generated name for given actor appropriate in specified context.
+		/// Note that NND might not have a name for the actor. In this case an empty string will be returned.
+		/// </summary>
+		/// <param name="actor">Actor for which the name should be retrieved.</param>
+		/// <param name="context">Context in which the name needs to be displayed. Depending on context name might either shortened or formatted differently.</param>
+		/// <returns>A name generated for the actor. If actor does not support generated names an empty string will be returned instead.</returns>
+		virtual std::string_view GetName(RE::ActorHandle actor, NameContext context) noexcept = 0;
+
+		/// <summary>
+		/// Retrieves a generated name for given actor appropriate in specified context.
+		/// Note that NND might not have a name for the actor. In this case an empty string will be returned.
+		/// </summary>
+		/// <param name="actor">Actor for which the name should be retrieved.</param>
+		/// <param name="context">Context in which the name needs to be displayed. Depending on context name might either shortened or formatted differently.</param>
+		/// <returns>A name generated for the actor. If actor does not support generated names an empty string will be returned instead.</returns>
+		virtual std::string_view GetName(const RE::Actor* actor, NameContext context) noexcept = 0;
+
+		/// <summary>
+		/// Reveals a real name of the given actor to the player. If player already knows actor's name this method does nothing.
+		/// This method can be used to programatically introduce an actor to the player.
+		/// </summary>
+		/// <param name="actor">Actor whose name should be revealed.</param>
+		virtual void RevealName(RE::ActorHandle actor) noexcept = 0;
+
+		/// <summary>
+		/// Reveals a real name of the given actor to the player. If player already knows actor's name this method does nothing.
+		/// This method can be used to programatically introduce an actor to the player.
+		/// </summary>
+		/// <param name="actor">Actor whose name should be revealed.</param>
+		virtual void RevealName(RE::Actor* actor) noexcept = 0;
+	};
+
+	typedef void* (*_RequestPluginAPI)(const InterfaceVersion interfaceVersion);
+
+	/// <summary>
+	/// Request the NND API interface.
+	/// Recommended: Send your request during or after SKSEMessagingInterface::kMessage_PostLoad to make sure the dll has already been loaded
+	/// </summary>
+	/// <param name="a_interfaceVersion">The interface version to request</param>
+	/// <returns>The pointer to the API singleton, or nullptr if request failed</returns>
+	[[nodiscard]] inline void* RequestPluginAPI(const InterfaceVersion a_interfaceVersion = InterfaceVersion::kV1)
+	{
+		const auto pluginHandle = GetModuleHandleA(reinterpret_cast<LPCSTR>("NPCsNamesDistributor.dll"));
+		if (const _RequestPluginAPI requestAPIFunction = reinterpret_cast<_RequestPluginAPI>(GetProcAddress(pluginHandle, "RequestPluginAPI"))) {
+			return requestAPIFunction(a_interfaceVersion);
+		}
+		return nullptr;
+	}
+}

--- a/include/NPCNameProvider.h
+++ b/include/NPCNameProvider.h
@@ -1,0 +1,28 @@
+#pragma once
+#include "NND_API.h"
+
+class NPCNameProvider
+{
+public:
+	static NPCNameProvider* GetSingleton()
+	{
+		static NPCNameProvider singleton;
+		return std::addressof(singleton);
+	}
+
+	const char* GetName(const RE::Actor* actor) const;
+
+	void RequestAPI();
+
+private:
+	NND_API::IVNND1* NND = nullptr;
+
+	NPCNameProvider() = default;
+	NPCNameProvider(const NPCNameProvider&) = delete;
+	NPCNameProvider(NPCNameProvider&&) = delete;
+
+	~NPCNameProvider() = default;
+
+	NPCNameProvider& operator=(const NPCNameProvider&) = delete;
+	NPCNameProvider& operator=(NPCNameProvider&&) = delete;
+};

--- a/src/NPCNameProvider.cpp
+++ b/src/NPCNameProvider.cpp
@@ -1,0 +1,29 @@
+#include "NPCNameProvider.h"
+#include "NND_API.h"
+
+const char* NPCNameProvider::GetName(const RE::Actor* actor) const
+{
+	if (NND) {
+		if (auto name = NND->GetName(actor, NND_API::NameContext::kSubtitles); !name.empty()) {
+			return name.data();
+		}
+	}
+
+	if (auto xTextData = actor->extraList.GetByType<RE::ExtraTextDisplayData>(); xTextData) {
+		return xTextData->displayName.c_str();
+	}
+
+	return actor->GetName();
+}
+
+void NPCNameProvider::RequestAPI()
+{
+	if (!NND) {
+		NND = static_cast<NND_API::IVNND1*>(NND_API::RequestPluginAPI(NND_API::InterfaceVersion::kV1));
+		if (NND) {
+			logger::info("Obtained NND API - {0:x}", reinterpret_cast<uintptr_t>(NND));
+		} else {
+			logger::info("Failed to obtain NND API");
+		}
+	}
+}

--- a/src/SubtitleManager.cpp
+++ b/src/SubtitleManager.cpp
@@ -1,14 +1,12 @@
-#include "SubtitleManager.h"
+#include "SubtitleManager.h" 
+#include "NPCNameProvider.h"
 
 namespace Subtitles
 {
 	const char* SubtitleManager::GetDisplayName(RE::TESObjectREFR* ref)
 	{
-		auto actor = ref ? ref->As<RE::Actor>() : nullptr;
-		auto xTextData = actor ? actor->extraList.GetByType<RE::ExtraTextDisplayData>() : nullptr;
-
-		if (xTextData) {
-			return xTextData->displayName.c_str();
+		if (auto actor = ref->As<RE::Actor>(); actor) {
+			return NPCNameProvider::GetSingleton()->GetName(actor);
 		} else {
 			return ref->GetName();
 		}

--- a/src/XSEPlugin.cpp
+++ b/src/XSEPlugin.cpp
@@ -1,6 +1,7 @@
 #define DLLEXPORT __declspec(dllexport)
 #include "Configuration.h"
 #include "Hooks.h"
+#include "NPCNameProvider.h"
 
 void InitializeLog([[maybe_unused]] spdlog::level::level_enum a_level = spdlog::level::info)
 {
@@ -31,10 +32,10 @@ void InitializeMessaging()
 	if (!SKSE::GetMessagingInterface()->RegisterListener([](SKSE::MessagingInterface::Message* message) {
 			switch (message->type) {
 			case SKSE::MessagingInterface::kDataLoaded:
+				NPCNameProvider::GetSingleton()->RequestAPI();
 				Subtitles::Hooks::Install();
 				Subtitles::Configuration::GetSingleton()->Initialize();
 				break;
-
 			default:
 				break;
 			}


### PR DESCRIPTION
Hey 🙂 great mod you have here! I immediately thought of adding a compatibility with NPCs Names Distributor, so that Subtitles can pick up generated names and show them in a proper "Subtitle" context.

With this change I introduced NND API and an `NPCNameProvider` that will try to use that API if present and there is a generated name to use, otherwise it falls back to the logic you had in place before.

Please, let me know if you have any concerns with this PR.