### PR TITLE
fix: fix nullref when using mantella/chim

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.21)
 
 project(
 	Subtitles
-	VERSION 0.6.1
+	VERSION 0.6.2
 	LANGUAGES CXX
 )
 

--- a/src/SubtitleManager.cpp
+++ b/src/SubtitleManager.cpp
@@ -1,4 +1,4 @@
-#include "SubtitleManager.h" 
+#include "SubtitleManager.h"
 #include "NPCNameProvider.h"
 
 namespace Subtitles
@@ -69,7 +69,12 @@ namespace Subtitles
 				}
 
 				// Talking Activators don't have a name, so handle that gracefully
-				auto speakerName = GetDisplayName(info->speaker.get().get());
+				const char* speakerName = "";
+				if (const auto speakerRefPtr = info->speaker.get(); speakerRefPtr) {
+					if (const auto speakerRef = speakerRefPtr.get(); speakerRef) {
+						speakerName = GetDisplayName(speakerRef);
+					}
+				}
 
 				if (showSpeakerName && speakerName && speakerName[0]) {
 					if (Configuration::GetSingleton()->dimBackgroundSubtitles) {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "subtitles",
-  "version-semver": "0.6.1",
+  "version-semver": "0.6.2",
   "description": "",
   "license": "CC0-1.0",
   "dependencies": [


### PR DESCRIPTION
Added nullreference check for speakerref when showing subtitles. 

Specifically an issue using together with mantella/chim. 

Have been tested by 5 people with around 14 hours total playtime with no crashing. 

also bumped version to 0.6.2